### PR TITLE
Update dropbox.rst

### DIFF
--- a/dropbox.rst
+++ b/dropbox.rst
@@ -2,7 +2,7 @@
 
 Cloud Settings
 ================
-| **Changing the dropbox or google drive settings is only effective if the device is being used as the camera.**
+| **Changing the Dropbox or Google Drive settings is only effective if the device is being used as the camera.**
 |
 | |user options|
 
@@ -12,17 +12,17 @@ Cloud Settings
 Folder Size
 -------------------
 | Sets the maximum reserved size for 24/7 video recordings.
-| The default size is 500MB. Maximum size can be 20GB.
+| The default size is 500 MB. Maximum size can be 20 GB.
 | New video log will automatically replace the oldest log.
 
 Max Saved Motion Events
 -----------------------
 | Sets the maximum number of saved motion detection events.
-| The default max saved events is 500.
+| The default max saved events is 500 events.
 | New motion event recording will automatically replace the oldest.
 
 24/7 Recording
 --------------
 | Enable 24/7 recording to start video log.
 | Camera will continuously record and upload video clips to your cloud space.
-| Enable 24/7 recording will consume lots of internet bandwidth.
+| Enable 24/7 recording will consume significant internet bandwidth.


### PR DESCRIPTION
.. _dropbox:

Cloud Settings
================
| **Changing the Dropbox or Google Drive settings is only effective if the device is being used as the camera.**
|
| |user options|

.. |user options| image:: img/dropbox_settings.png
  :width: 300pt

Folder Size
-------------------
| Sets the maximum reserved size for 24/7 video recordings.
| The default size is 500 MB. Maximum size can be 20 GB.
| New video log will automatically replace the oldest log.

Max Saved Motion Events
-----------------------
| Sets the maximum number of saved motion detection events.
| The default max saved events is 500 events.
| New motion event recording will automatically replace the oldest.

24/7 Recording
--------------
| Enable 24/7 recording to start video log.
| Camera will continuously record and upload video clips to your cloud space.
| Enable 24/7 recording will consume significant internet bandwidth.